### PR TITLE
added flushing of testprogram's output, so you can use tdaemon in a pipe on the commandline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
-.pyc
+*.pyc
+dist
+*.egg-info

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,11 @@
-Copyright (c) 2008-2009 Bruno Bord
+License
+=======
+
+MIT license
+
+http://www.opensource.org/licenses/mit-license.php
+
+Copyright (c) 2008-2009 Bruno Bord and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -17,4 +24,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
-

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+exclude test.py
+exclude README.md
+exclude MANIFEST.in

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,31 @@
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
+    
+setup(
+    name = "tdaemon",
+    version = "0.1.1",
+    maintainer = "John Paulett",
+    maintainer_email = "john@7oars.com",
+    description = "Test Daemon",
+    long_description = "The test daemon watches the content of files in a directory and if any of them changes (the content is edited), it runs the tests.",
+    url = "http://github.com/brunobord/tdaemon",
+    license = "MIT",
+    platforms = ['POSIX', 'Windows'],
+    keywords = ['test', 'testing', 'noestests', 'django', 'py.test'],
+    classifiers = [
+        "License :: OSI Approved :: MIT License",
+        "Topic :: Software Development :: Testing",
+        "Programming Language :: Python",
+        "Intended Audience :: Developers",
+    ],    
+    entry_points = {
+      'console_scripts': [
+        'tdaemon = tdaemon:main',
+      ],
+    },
+    py_modules = ['tdaemon'],
+
+)
+

--- a/tdaemon.py
+++ b/tdaemon.py
@@ -200,6 +200,7 @@ class Watcher(object):
         output = subprocess.Popen(cmd, shell=True)
         output = output.communicate()[0]
         print output
+        sys.stdout.flush()
 
     def run_tests(self):
         """Execute tests"""


### PR DESCRIPTION
...  like so:

``` bash
tdaemon | tee /dev/stderr| while read line; do  test "${line:0:6}" == "FAILED" && call_my_fancy_notifier ; done
```

Before nothing would come through the pipe.
Also added setup.py from the sdist on pypi to this git repo
