### PR TITLE
fix: Add .tox to default list of dirs to exclude

### DIFF
--- a/tdaemon.py
+++ b/tdaemon.py
@@ -23,7 +23,7 @@ import subprocess
 
 SPECIAL_CHARS_REGEX_PATTERN = r'[#&;`|*?~<>^()\[\]{}$\\]+' 
 IGNORE_EXTENSIONS = ('pyc', 'pyo')
-IGNORE_DIRS = ('.bzr', '.git', '.hg', '.darcs', '.svn')
+IGNORE_DIRS = ('.bzr', '.git', '.hg', '.darcs', '.svn', '.tox')
 IMPLEMENTED_TEST_PROGRAMS = ('nose', 'nosetests', 'django', 'py', 'symfony',
     'jelix', 'phpunit', 'sphinx',
 )


### PR DESCRIPTION
Tox is a fairly popular testing framework anymore, and so I think it makes sense to ignore it's cache directory by default.
