### PR TITLE
Added prefix option to allow prefixed command.

### DIFF
--- a/tdaemon.py
+++ b/tdaemon.py
@@ -154,7 +154,7 @@ class Watcher(object):
         elif self.test_program == 'tox':
             cmd = 'tox'
         # Add custom prefix to the start of the command.
-        if self.prefix:
+        if cmd and self.prefix:
             cmd = ' '.join([self.prefix, cmd])
 
         if not cmd:

--- a/tdaemon.py
+++ b/tdaemon.py
@@ -138,8 +138,6 @@ class Watcher(object):
             executable = "%s/manage.py" % self.file_path
             if os.path.exists(executable):
                 cmd = "python %s/manage.py test" % self.file_path
-                if self.prefix:
-                    cmd = ' '.join([self.prefix, cmd])
             else:
                 cmd = "django-admin.py test"
         elif self.test_program == 'py':
@@ -155,6 +153,9 @@ class Watcher(object):
             cmd = 'make html'
         elif self.test_program == 'tox':
             cmd = 'tox'
+        # Add custom prefix to the start of the command.
+        if self.prefix:
+            cmd = ' '.join([self.prefix, cmd])
 
         if not cmd:
             raise InvalidTestProgram("The test program %s is unknown. Valid options are: `nose`, `django` and `py`" % self.test_program)


### PR DESCRIPTION
I added a "prefix" command-line option to allow test runner commands to be prefixed with a custom argument. I added this to specifically assist my own development, as I'm using Honcho to set environment variables for a Django project (e.g. I need to run "honcho run python manage.py test" in my setup).

I've only tested it with Django, but it shouldn't interfere with other test commands.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/brunobord/tdaemon/15)

<!-- Reviewable:end -->
